### PR TITLE
Fix distribution strategy

### DIFF
--- a/app/services/reaction_service.rb
+++ b/app/services/reaction_service.rb
@@ -33,10 +33,8 @@ class ReactionService < BaseService
 
     if status.account.local?
       LocalNotificationWorker.perform_async(status.account_id, reaction.id, 'Reaction', 'reaction')
-      ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id)
-    elsif status.account.activitypub?
-      ActivityPub::DeliveryWorker.perform_async(build_json(reaction), reaction.account_id, status.account.inbox_url)
     end
+    ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id, status.account.inbox_url)
   end
 
   def bump_potential_friendship(account, status)

--- a/app/services/unreaction_service.rb
+++ b/app/services/unreaction_service.rb
@@ -14,11 +14,7 @@ class UnreactionService < BaseService
 
   def create_notification(current_account, reaction)
     status = reaction.status
-    if status.account.local?
-      ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id)
-    elsif status.account.activitypub?
-      ActivityPub::DeliveryWorker.perform_async(build_json(reaction), reaction.account_id, status.account.inbox_url)
-    end
+    ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id, status.account.inbox_url)
   end
 
   def build_json(reaction)

--- a/app/workers/activitypub/reactions_distribution_worker.rb
+++ b/app/workers/activitypub/reactions_distribution_worker.rb
@@ -3,9 +3,10 @@
 class ActivityPub::ReactionsDistributionWorker < ActivityPub::RawDistributionWorker
   # Distribute reactions to servers that might have a copy
   # of the account in question
-  def perform(json, source_account_id)
-    @account = Account.find(source_account_id)
-    @json    = json
+  def perform(json, source_account_id, target_inbox_url)
+    @account        = Account.find(source_account_id)
+    @json           = json
+    @target_inboxes = [target_inbox_url]
 
     distribute!
   rescue ActiveRecord::RecordNotFound
@@ -15,7 +16,7 @@ class ActivityPub::ReactionsDistributionWorker < ActivityPub::RawDistributionWor
   protected
 
   def inboxes
-    @inboxes ||= AccountReachFinder.new(@account).inboxes
+    @inboxes ||= (AccountReachFinder.new(@account).inboxes + @target_inboxes).uniq
   end
 
   def payload


### PR DESCRIPTION
全ての投稿に対して、リアクションを付けた人をFollowしているRemoteへ配送するのがMisskey流らしいので動作をそろえた