### PR TITLE
Fix info-string parsing

### DIFF
--- a/app/javascript/mastodon/actions/importer/highlighter.js
+++ b/app/javascript/mastodon/actions/importer/highlighter.js
@@ -3,7 +3,7 @@ import hljs from 'highlight.js';
 const BlockElement = 'address|blockquote|center|div|dl|fieldset|form|h[1-6]|hr|noframes|noscript|ol|p|pre|table|ul|br';
 const BlockTag = `<\\/?(?:${BlockElement})[^>]*\\/?>`;
 const AsLineBreak = new RegExp(BlockTag, 'g');
-const CodeBlock = new RegExp(`(?:^|${BlockTag})\\s*(\`\`\`)([a-zA-Z0-9-]*)\\s*(?=$|${BlockTag})`, 'g');
+const CodeBlock = new RegExp(`(?:^|${BlockTag})\\s*(\`\`\`)([^\\s]*?)(\\s+.*?)?(?=$|\r|\n|${BlockTag})`, 'g');
 const InlineCodeBlock = /`([^`<>]+)`/g;
 
 function createHighlighIndecis(input) {


### PR DESCRIPTION
````
```ninnino_mojide_OK
```
````
任意の文字がOKで空白を含む場合、空白を含まない先頭の一致を採用するのが正しいっぽいので挙動を修正した