### PR TITLE
Increse poll input font-size

### DIFF
--- a/app/javascript/styles/mastodon/polls.scss
+++ b/app/javascript/styles/mastodon/polls.scss
@@ -89,6 +89,11 @@
       &:focus {
         border-color: $highlight-text-color;
       }
+
+      @media screen and (max-width: 600px) {
+        font-size: 16px;
+        padding: 5px 10px;
+      }
     }
 
     &.selectable {


### PR DESCRIPTION
Minimum font size needs 16px to avoid zooming on iOS Safari