### PR TITLE
Use shared_inbox_url to deliver reactions to remote

### DIFF
--- a/app/services/reaction_service.rb
+++ b/app/services/reaction_service.rb
@@ -34,7 +34,7 @@ class ReactionService < BaseService
     if status.account.local?
       LocalNotificationWorker.perform_async(status.account_id, reaction.id, 'Reaction', 'reaction')
     end
-    ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id, status.account.inbox_url)
+    ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id, status.account.shared_inbox_url)
   end
 
   def bump_potential_friendship(account, status)

--- a/app/services/unreaction_service.rb
+++ b/app/services/unreaction_service.rb
@@ -14,7 +14,7 @@ class UnreactionService < BaseService
 
   def create_notification(current_account, reaction)
     status = reaction.status
-    ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id, status.account.inbox_url)
+    ActivityPub::ReactionsDistributionWorker.perform_async(build_json(reaction), current_account.id, status.account.shared_inbox_url)
   end
 
   def build_json(reaction)

--- a/app/workers/activitypub/reactions_distribution_worker.rb
+++ b/app/workers/activitypub/reactions_distribution_worker.rb
@@ -6,7 +6,11 @@ class ActivityPub::ReactionsDistributionWorker < ActivityPub::RawDistributionWor
   def perform(json, source_account_id, target_inbox_url)
     @account        = Account.find(source_account_id)
     @json           = json
-    @target_inboxes = [target_inbox_url]
+    if target_inbox_url.empty? then
+      @target_inboxes = []
+    else
+      @target_inboxes = [target_inbox_url]
+    end
 
     distribute!
   rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
Remoteへ配送するときはinbox_urlではなくshared_inbox_urlを使うようにした。