### PR TITLE
Support Fedibird style reactions api

### DIFF
--- a/app/controllers/api/v1/statuses/reactions_controller.rb
+++ b/app/controllers/api/v1/statuses/reactions_controller.rb
@@ -5,10 +5,15 @@ class Api::V1::Statuses::ReactionsController < Api::BaseController
 
   before_action -> { doorkeeper_authorize! :write, :'write:favourites' }
   before_action :require_user!
-  before_action :set_status, only: [:create]
+  before_action :set_status, only: [:create, :update]
 
   def create
     ReactionService.new.call(current_account, @status, params[:name])
+    render json: @status, serializer: REST::StatusSerializer
+  end
+
+  def update
+    ReactionService.new.call(current_account, @status, params[:id])
     render json: @status, serializer: REST::StatusSerializer
   end
 

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -11,7 +11,8 @@ class REST::InstanceSerializer < ActiveModel::Serializer
 
   attributes :domain, :title, :version, :source_url, :description,
              :usage, :thumbnail, :languages, :configuration,
-             :registrations
+             :registrations,
+             :fedibird_capabilities
 
   has_one :contact, serializer: ContactSerializer
   has_many :rules, serializer: REST::RuleSerializer
@@ -78,6 +79,14 @@ class REST::InstanceSerializer < ActiveModel::Serializer
         enabled: TranslationService.configured?,
       },
     }
+  end
+
+  def fedibird_capabilities
+    [
+      :emoji_reaction,
+      :enable_wide_emoji,
+      :enable_wide_emoji_reaction,
+    ]
   end
 
   def registrations

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -14,6 +14,8 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :muted, if: :current_user?
   attribute :bookmarked, if: :current_user?
   attribute :pinned, if: :pinnable?
+  # Fedibird compatibility
+  attribute :emoji_reactioned, if: :current_user?
   has_many :filtered, serializer: REST::FilterResultSerializer, if: :current_user?
 
   attribute :content, unless: :source_requested?
@@ -28,6 +30,8 @@ class REST::StatusSerializer < ActiveModel::Serializer
   has_many :tags
   has_many :emojis, serializer: REST::CustomEmojiSerializer
   has_many :reactions, serializer: REST::StatusReactionSerializer
+  # Fedibird compatibility
+  has_many :emoji_reactions, serializer: REST::StatusReactionSerializer
 
   has_one :preview_card, key: :card, serializer: REST::PreviewCardSerializer
   has_one :preloadable_poll, key: :poll, serializer: REST::PollSerializer
@@ -101,6 +105,14 @@ class REST::StatusSerializer < ActiveModel::Serializer
 
   def reactions
     object.reactions_hash(current_user&.account)
+  end
+
+  def emoji_reactioned
+    self.reacted
+  end
+
+  def emoji_reactions
+    self.reactions
   end
 
   def reblogged

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -6,7 +6,8 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
   attributes :uri, :title, :short_description, :description, :email,
              :version, :urls, :stats, :thumbnail,
              :languages, :registrations, :approval_required, :invites_enabled,
-             :configuration
+             :configuration,
+             :fedibird_capabilities
 
   has_one :contact_account, serializer: REST::AccountSerializer
 
@@ -96,6 +97,14 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
 
   def invites_enabled
     UserRole.everyone.can?(:invite_users)
+  end
+
+  def fedibird_capabilities
+    [
+      :emoji_reaction,
+      :enable_wide_emoji,
+      :enable_wide_emoji_reaction,
+    ]
   end
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -451,6 +451,10 @@ Rails.application.routes.draw do
           resource :reaction, only: :create
           post :unreaction, to: 'reactions#destroy'
 
+          # Fedibird copatible endpoints
+          resources :emoji_reactions, only: :update, constraints: { id: /[^\/]+/ }, controller: 'reactions'
+          post :emoji_unreactions, to: 'reactions#destroy'
+
           resource :bookmark, only: :create
           post :unbookmark, to: 'bookmarks#destroy'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -452,7 +452,7 @@ Rails.application.routes.draw do
           post :unreaction, to: 'reactions#destroy'
 
           # Fedibird copatible endpoints
-          resources :emoji_reactions, only: :update, constraints: { id: /[^\/]+/ }, controller: 'reactions'
+          resources :emoji_reactions, only: [:update, :destroy], constraints: { id: /[^\/]+/ }, controller: 'reactions'
           post :emoji_unreactions, to: 'reactions#destroy'
 
           resource :bookmark, only: :create


### PR DESCRIPTION
Fedibirdっぽくふるまっていますが完全に互換ではないです。

- つけられるリアクションは1つまでです
- DELETEの `:emoji` は何を付けても無視されます
- 通知は互換ではありません
- 他インスタンスの絵文字はつけられません

PUT /api/v1/statuses/:id/emoji_reactions/:emoji
DELETE /api/v1/statuses/:id/emoji_reactions/:emoji
POST /api/v1/statuses/:id/emoji_unreactions