### PR TITLE
リモートからカスタム絵文字のリアクションのundoが来た時に動作していないのを修正

### DIFF
--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -135,11 +135,11 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
     return if status.nil? || !status.account.local?
     
     if @object['tag'].present?
-      as_array(@json['tag']).each do |tag|
+      as_array(@object['tag']).each do |tag|
         if equals_or_includes?(tag['type'], 'Emoji')
           custom_emoji_parser = ActivityPub::Parser::CustomEmojiParser.new(tag)
           emoji = CustomEmoji.find_by(shortcode: custom_emoji_parser.shortcode, domain: custom_emoji_parser.domain)
-          if @account.custom_emoji_reacted?(status, custom_emoji)
+          if @account.custom_emoji_reacted?(status, emoji)
             reaction = status.reactions.where(account: @account, custom_emoji: emoji).first
             reaction&.destroy
           end


### PR DESCRIPTION
直接マージしたかったけどうまくいかなかったのでcherry-pickしました

Special thanks: https://github.com/F-Finene/mastodon/commit/d294bea8de17ebe4a10b0d1c32c2803a3ab35072