### PR TITLE
increase media_proxy ratelimit for authenticated user

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -82,8 +82,12 @@ class Rack::Attack
     req.authenticated_user_id if req.post? && req.path.match?(%r{\A/api/v\d+/media\z}i)
   end
 
-  throttle('throttle_media_proxy', limit: 30, period: 10.minutes) do |req|
-    req.throttleable_remote_ip if req.path.start_with?('/media_proxy')
+  throttle('throttle_authenticated_media_proxy', limit: 150, period: 5.minutes) do |req|
+    req.authenticated_user_id if req.path.start_with?('/media_proxy')
+  end
+
+  throttle('throttle_unauthenticated_media_proxy', limit: 30, period: 10.minutes) do |req|
+    req.throttleable_remote_ip if req.path.start_with?('/media_proxy') && req.unauthenticated?
   end
 
   throttle('throttle_api_sign_up', limit: 5, period: 30.minutes) do |req|


### PR DESCRIPTION
Increase `media_proxy` limitation for authenticated users.

- before
  - unauthenticated user
    - 30times/10min.
  - authenticated user
    - 30times/10min.
- after
  - unauthenticated user
    - 30times/10min.
  - authenticated user
    - 150times/5min.