### PR TITLE
Fix EmojiReact interoperability for Fedibird

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -28,6 +28,9 @@ class ActivityPub::Activity
     private
 
     def klass
+      # Support litepub:EmojiReact
+      @json['type'] = 'EmojiReact' if @json['type'].eql?('http://litepub.social/ns#EmojiReact')
+      # Support misskey style emoji react
       @json['type'] = 'EmojiReact' if @json['type'].eql?('Like') && @json['content'].present?
 
       case @json['type']


### PR DESCRIPTION
Fedibird and some instances send type prefixed with "litepub:" namespace.