### PR TITLE
Fix EmojiReact interoperability with Pleroma

### DIFF
--- a/app/lib/activitypub/activity/emoji_react.rb
+++ b/app/lib/activitypub/activity/emoji_react.rb
@@ -10,7 +10,7 @@ class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
 
     process_tags
 
-    reaction = original_status.reactions.create!(account: @account, name: @json['content']) if @json['tag'].nil? && !@account.reacted_with?(original_status, @json['content'])
+    reaction = original_status.reactions.create!(account: @account, name: @json['content']) if @json['tag'].blank? && !@account.reacted_with?(original_status, @json['content'])
 
     reaction = original_status.reactions.create!(account: @account, name: @json['content']&.delete(':'), custom_emoji: @emoji) if @emoji.present? && !@account.custom_emoji_reacted?(original_status, @emoji)
 


### PR DESCRIPTION
Pleroma sends EmojiReact payload with empty tag field.